### PR TITLE
ci: use self-hosted runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   Release:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.3

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   verify:
     name: Verify PR
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.3


### PR DESCRIPTION
Replace compatible GitHub-hosted runner selections with the self-hosted runner.